### PR TITLE
Fix developer sessions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This installation method is to try out the theme while developing it. If you're 
 git clone https://github.com/ubuntu/communitheme.git
 cd communitheme
 # Initialize build system (only required once per repo)
-meson build --prefix=/usr/local
+meson build
 cd build
 # Build and install
 sudo ninja install

--- a/build-helpers/replace-name
+++ b/build-helpers/replace-name
@@ -8,4 +8,4 @@ _, input_f, output_f, generic_name, project_name = sys.argv
 with open(output_f, 'w') as output:
     with open(input_f) as input:
         for s in input:
-            output.write(s.replace(generic_name, project_name))
+            output.write(s.replace(generic_name, project_name).replace(generic_name.lower(), project_name.lower()))

--- a/sessions/THEMENAME-wayland.desktop.in
+++ b/sessions/THEMENAME-wayland.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=THEMENAME session on wayland
 Comment=This session logs you with THEMENAME on wayland
-Exec=env GNOME_SHELL_SESSION_MODE=THEMENAME gnome-session
+Exec=env GNOME_SHELL_SESSION_MODE=themename gnome-session
 TryExec=gnome-session
 Type=Application
 DesktopNames=THEMENAME:ubuntu:GNOME

--- a/sessions/THEMENAME-wayland.desktop.in
+++ b/sessions/THEMENAME-wayland.desktop.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=THEMENAME session on wayland
+Comment=This session logs you with THEMENAME on wayland
+Exec=env GNOME_SHELL_SESSION_MODE=THEMENAME gnome-session
+TryExec=gnome-session
+Type=Application
+DesktopNames=THEMENAME:ubuntu:GNOME
+X-Ubuntu-Gettext-Domain=gnome-session-3.0

--- a/sessions/THEMENAME.desktop.in
+++ b/sessions/THEMENAME.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=THEMENAME session
 Comment=This session logs you with THEMENAME
-Exec=env GNOME_SHELL_SESSION_MODE=THEMENAME gnome-session
+Exec=env GNOME_SHELL_SESSION_MODE=themename gnome-session
 TryExec=gnome-session
 Type=Application
 DesktopNames=THEMENAME:ubuntu:GNOME

--- a/sessions/meson.build
+++ b/sessions/meson.build
@@ -11,7 +11,6 @@ custom_target('shell-mode',
               install: true,
               install_dir: gnomeshell_mode_dir)
 
-xsession_dir = join_paths(get_option('datadir'), 'xsessions')
 custom_target('desktop-xsession',
               input: 'THEMENAME.desktop.in',
               output: meson.project_name()+'.desktop',
@@ -20,8 +19,16 @@ custom_target('desktop-xsession',
               ],
               build_by_default: true,
               install: true,
-              install_dir: xsession_dir)
-meson.add_install_script('meson/copy-to-wayland-session', meson.project_name())
+              install_dir: join_paths(get_option('datadir'), 'xsessions'))
+custom_target('desktop-waylandsession',
+              input: 'THEMENAME-wayland.desktop.in',
+              output: meson.project_name()+'-wayland.desktop',
+              command: [
+                replace_name, '@INPUT@', '@OUTPUT@', 'THEMENAME', meson.project_name()
+              ],
+              build_by_default: true,
+              install: true,
+              install_dir: join_paths(get_option('datadir'), 'wayland-sessions'))
 
 gsettings_override_dir = join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
 custom_target('gsettings-override',

--- a/sessions/meson.build
+++ b/sessions/meson.build
@@ -1,9 +1,10 @@
 gnomeshell_mode_dir = join_paths(get_option('datadir'), 'gnome-shell', 'modes')
 
+# NOTE: GNOME Shell only accept lowercase mode names.
 replace_name = find_program('../build-helpers/replace-name')
 custom_target('shell-mode',
               input: 'mode.json.in',
-              output: meson.project_name()+'.json',
+              output: meson.project_name().to_lower()+'.json',
               command: [
                 replace_name, '@INPUT@', '@OUTPUT@', 'THEMENAME', meson.project_name()
               ],

--- a/sessions/meson/copy-to-wayland-session
+++ b/sessions/meson/copy-to-wayland-session
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-mkdir -p "${MESON_INSTALL_DESTDIR_PREFIX}/share/wayland-sessions"
-cp -a "${MESON_INSTALL_DESTDIR_PREFIX}/share/xsessions/$1.desktop" "${MESON_INSTALL_DESTDIR_PREFIX}/share/wayland-sessions/$1.desktop"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,6 @@ parts:
       sed -i 's/Communitheme/Suru/' $SNAPCRAFT_PART_INSTALL/share/icons/Suru/index.theme
       mv $SNAPCRAFT_PART_INSTALL/share/sounds/Communitheme $SNAPCRAFT_PART_INSTALL/share/sounds/communitheme
       sed -i 's/Communitheme/communitheme/' $SNAPCRAFT_PART_INSTALL/share/sounds/communitheme/*.theme
-      mv $SNAPCRAFT_PART_INSTALL/share/gnome-shell/modes/Communitheme.json $SNAPCRAFT_PART_INSTALL/share/gnome-shell/modes/ubuntu-communitheme.json
+      mv $SNAPCRAFT_PART_INSTALL/share/gnome-shell/modes/communitheme.json $SNAPCRAFT_PART_INSTALL/share/gnome-shell/modes/ubuntu-communitheme.json
       # remove unused artefacts in the snap (sessions and schemas)
       rm -rf $SNAPCRAFT_PART_INSTALL/share/*sessions $SNAPCRAFT_PART_INSTALL/share/glib-2.0


### PR DESCRIPTION
This install correct mode and names for them, following requirement
* Fallback to /usr for dev installation
GDM doesn't know about /usr/local and it's something we can't SRU easily
to bionic, we need to fallback thus to /usr for developers :/
As long as devs don't install the package version, that's fine.
* Add a separate wayland session
Separate wayland from xsession so that developers can choose between the 2.
* GNOME Shell only accept lowercase mode names
Ensure both reference and filename are lowercase to match GNOME Shell
requirements on those.
Make the renamer a little bit smarter if we use the keyword as a
lowercase.
Fixes #634.
