### PR TITLE
Fixed some gnome-shell error messages

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -150,6 +150,7 @@ StScrollBar {
   height: 1em;
   -slider-height: 0.2em; //increase the height because of the border removal
   -slider-background-color:  $_inactive_bg;//background of the trough
+  -slider-border-color: $borders_color; //trough border color
   -slider-active-background-color: $_bg; //active trough fill
   -slider-active-border-color: $_bg; //active trough border
   -slider-border-width: 0px; //remove the border for a more flat trough

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -202,7 +202,7 @@
     &:hover, &:active, &:checked {
       .show-apps-icon {
         background-image: url("ubuntu-appgrid-icon.svg") !important;
-        background-position: center;
+        /* background-position: center; non-number values seems not supported see #653 */
         background-repeat: no-repeat;
         background-size: contain !important;
       }


### PR DESCRIPTION
- reset -slider-border-color property
- removed background-size property with value "contain" from .show-apps-icon
    it seems that gnome-shell does not support non-numeric values

closes #653