### PR TITLE
Install override file for ubuntu-dock style

### DIFF
--- a/sessions/meson.build
+++ b/sessions/meson.build
@@ -42,4 +42,5 @@ custom_target('gsettings-override',
               install: true,
               install_dir: gsettings_override_dir)
 
+meson.add_install_script('meson/install-dock-override', meson.project_name().to_lower())
 meson.add_install_script('meson/compile-schemas')

--- a/sessions/meson/install-dock-override
+++ b/sessions/meson/install-dock-override
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+DOCK_DIR="${MESON_INSTALL_DESTDIR_PREFIX}/share/gnome-shell/extensions/ubuntu-dock@ubuntu.com"
+
+mkdir -p "${DOCK_DIR}"
+touch "${DOCK_DIR}/$1.css"


### PR DESCRIPTION
Create an empty file matching mode name to let main css file override
ubuntu-dock style one.
Fixes: #637.