### PR TITLE
Aligned again small title button in chrome/chromium

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -491,10 +491,10 @@ window.background.chromium {
     padding: 0;
 
     &:not(.appmenu){
-      &:hover { @include draw_circle($headerbar_bg_color, $size:20px) ; }
+      &:hover { @include draw_circle($headerbar_bg_color, $size:16px) ; }
     }
     &.close:not(:backdrop) {
-      @include draw_circle($selected_bg_color, $close:true, $size:20px);
+      @include draw_circle($selected_bg_color, $close:true, $size:16px);
     }
   }
   menuitem { border-radius: 0; }


### PR DESCRIPTION
Closes #412 again

before
![screenshot from 2018-07-22 16-12-40](https://user-images.githubusercontent.com/2883614/43046688-d38cc054-8dcc-11e8-8718-e9bbedfef11d.png)

after
![screenshot from 2018-07-22 16-28-19](https://user-images.githubusercontent.com/2883614/43046697-e9055eb4-8dcc-11e8-8d84-b9e3e7e06d78.png)


