### PR TITLE
Restyled Software updater technical description box

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -2412,11 +2412,11 @@ notebook {
     padding: 1px;
     border-color: $borders_color;
     border-width: 1px;
-    background-color: $sidebar_bg_color;
+    background: if($variant==light, $porcelain, $base_color);
 
     &:backdrop {
       border-color: $backdrop_borders_color;
-      background-color: $backdrop_sidebar_bg_color;
+      background-color: $backdrop_bg_color;
     }
 
     tabs { margin: -1px; }
@@ -3767,6 +3767,10 @@ row {
  * Expanders *
  *************/
 expander {
+  notebook {
+    border: 1px solid $borders_color;
+  }
+
   arrow {
     min-width: 16px;
     min-height: 16px;


### PR DESCRIPTION
- added border to the box
- fixed notebook header color (it was white as the tabs)

closes #505 

![image](https://user-images.githubusercontent.com/2883614/43047973-517888be-8de0-11e8-81c1-e8b1bd9c7f66.png)

Backdrop
![image](https://user-images.githubusercontent.com/2883614/43047976-5b0eadf4-8de0-11e8-9689-f02c8e355b91.png)



