### PR TITLE
Use upstream appgrid icon.

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -186,26 +186,11 @@
   }
 
   .show-apps {
-    // Show apps icon
-    & {
-      // reset
-      & .show-apps-icon,
-      &:checked .show-apps-icon,
-      &:focus .show-apps-icon {
-        color: transparent !important;
-        background-color: transparent !important;
-        transition-duration: 0ms !important;
-      }
+    .overview-icon {
+      border-radius: $small_radius;
     }
-
-    &,
-    &:hover, &:active, &:checked {
-      .show-apps-icon {
-        background-image: url("ubuntu-appgrid-icon.svg") !important;
-        /* background-position: center; non-number values seems not supported see #653 */
-        background-repeat: no-repeat;
-        background-size: contain !important;
-      }
+    &:active, &:checked {
+      background-color: $base_active_color; box-shadow: none;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/ubuntu/communitheme/issues/584

We tried several iterations of a new appgrid icon but came to the conclusion to completely follow upstream.