### PR TITLE
Press effect only for the icon, add missing line.

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -190,7 +190,9 @@
       border-radius: $small_radius;
     }
     &:active, &:checked {
-      background-color: $base_active_color; box-shadow: none;
+      .overview-icon {
+        background-color: $base_active_color; box-shadow: none;
+      }
     }
   }
 


### PR DESCRIPTION
Fix missing line so the press effect is only for the icon:

![peek 2018-07-23 00-35](https://user-images.githubusercontent.com/15329494/43050877-65b5c4e2-8e10-11e8-8b81-2962d5e07d34.gif)

